### PR TITLE
fix: building images

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,48 @@
+name: build images
+
+on:
+  workflow_call:
+  push:
+    branches: [ "*", "**/*" ]
+
+jobs:
+
+  buildImages:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-go@v3
+      with:
+        go-version: '^1.21'
+  
+    - name: Set up Docker context for Buildx
+      id: buildx-context
+      run: |
+        docker context create builders
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v2
+      with:
+        version: latest
+        endpoint: builders
+
+    - run: go mod vendor
+
+    - name: Login to Container Registry
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build images
+      id: buildimages
+      run: |
+        img=ghcr.io/${{github.repository}}:${{github.sha}}
+        make build
+        make REGISTRY=ghcr.io/${{github.repository}} TAG=v1.5.1-${{github.sha}} image-chroot
+        docker push ghcr.io/${{github.repository}}/controller-chroot:v1.5.1-${{github.sha}}
+       


### PR DESCRIPTION
 # Context

 In #2 we merged the build image to main branch and also when trying the
produced image in a dev cluster we get an error

```
Unable to save changes: application spec for schip-ingress-public is invalid: InvalidSpecError: Unable to generate manifests in : rpc error: code = Unknown desc = `helm template . --name-template schip-ingress-public --namespace platform-services --kube-version 1.25 --values /tmp/6350c668-7e2b-4a9e-a604-b61a097602e1 --api-versions acme.cert-manager.io/v1 --api-versions acme.cert-manager.io/v1/Challenge --api-versions acme.cert-manager.io/v1/Order --api-versions admissionregistration.k8s.io/v1 --api-versions admissionregistration.k8s.io/v1/MutatingWebhookConfiguration --api-versions admissionregistration.k8s.io/v1/ValidatingWebhookConfiguration --api-versions apiextensions.k8s.io/v1 --api-versions apiextensions.k8s.io/v1/CustomResourceDefinition --api-versions apiregistration.k8s.io/v1 --api-versions apiregistration.k8s.io/v1/APIService --api-versions apps/v1 --api-versions apps/v1/ControllerRevision --api-versions apps/v1/DaemonSet --api-versions apps/v1/Deployment --api-versions apps/v1/ReplicaSet --api-versions apps/v1/StatefulSet --api-versions argoproj.io/v1alpha1 --api-versions argoproj.io/v1alpha1/AppProject --api-versions argoproj.io/v1alpha1/Application --api-versions argoproj.io/v1alpha1/ApplicationSet --api-versions autoscaling.k8s.io/v1 --api-versions autoscaling.k8s.io/v1/VerticalPodAutoscaler --api-versions autoscaling.k8s.io/v1/VerticalPodAutoscalerCheckpoint --api-versions autoscaling.k8s.io/v1beta2 --api-versions autoscaling.k8s.io/v1beta2/VerticalPodAutoscaler --api-versions autoscaling.k8s.io/v1beta2/VerticalPodAutoscalerCheckpoint --api-versions autoscaling/v1 --api-versions autoscaling/v1/HorizontalPodAutoscaler --api-versions autoscaling/v2 --api-versions autoscaling/v2/HorizontalPodAutoscaler --api-versions autoscaling/v2beta2 --api-versions autoscaling/v2beta2/HorizontalPodAutoscaler --api-versions batch/v1 --api-versions batch/v1/CronJob --api-versions batch/v1/Job --api-versions bitnami.com/v1alpha1 --api-versions bitnami.com/v1alpha1/SealedSecret --api-versions cert-manager.io/v1 --api-versions cert-manager.io/v1/Certificate --api-versions cert-manager.io/v1/CertificateRequest --api-versions cert-manager.io/v1/ClusterIssuer --api-versions cert-manager.io/v1/Issuer --api-versions certificates.k8s.io/v1 --api-versions certificates.k8s.io/v1/CertificateSigningRequest --api-versions config.gatekeeper.sh/v1alpha1 --api-versions config.gatekeeper.sh/v1alpha1/Config --api-versions coordination.k8s.io/v1 --api-versions coordination.k8s.io/v1/Lease --api-versions crd.k8s.amazonaws.com/v1alpha1 --api-versions crd.k8s.amazonaws.com/v1alpha1/ENIConfig --api-versions crd.projectcalico.org/v1 --api-versions crd.projectcalico.org/v1/BGPConfiguration --api-versions crd.projectcalico.org/v1/BGPPeer --api-versions crd.projectcalico.org/v1/BlockAffinity --api-versions crd.projectcalico.org/v1/CalicoNodeStatus --api-versions crd.projectcalico.org/v1/ClusterInformation --api-versions crd.projectcalico.org/v1/FelixConfiguration --api-versions crd.projectcalico.org/v1/GlobalNetworkPolicy --api-versions crd.projectcalico.org/v1/GlobalNetworkSet --api-versions crd.projectcalico.org/v1/HostEndpoint --api-versions crd.projectcalico.org/v1/IPAMBlock --api-versions crd.projectcalico.org/v1/IPAMConfig --api-versions crd.projectcalico.org/v1/IPAMHandle --api-versions crd.projectcalico.org/v1/IPPool --api-versions crd.projectcalico.org/v1/IPReservation --api-versions crd.projectcalico.org/v1/KubeControllersConfiguration --api-versions crd.projectcalico.org/v1/NetworkPolicy --api-versions crd.projectcalico.org/v1/NetworkSet --api-versions discovery.k8s.io/v1 --api-versions discovery.k8s.io/v1/EndpointSlice --api-versions events.k8s.io/v1 --api-versions events.k8s.io/v1/Event --api-versions expansion.gatekeeper.sh/v1alpha1 --api-versions expansion.gatekeeper.sh/v1alpha1/ExpansionTemplate --api-versions external-secrets.io/v1alpha1 --api-versions external-secrets.io/v1alpha1/ClusterSecretStore --api-versions external-secrets.io/v1alpha1/ExternalSecret --api-versions external-secrets.io/v1alpha1/SecretStore --api-versions external-secrets.io/v1beta1 --api-versions external-secrets.io/v1beta1/ClusterExternalSecret --api-versions external-secrets.io/v1beta1/ClusterSecretStore --api-versions external-secrets.io/v1beta1/ExternalSecret --api-versions external-secrets.io/v1beta1/SecretStore --api-versions externaldata.gatekeeper.sh/v1alpha1 --api-versions externaldata.gatekeeper.sh/v1alpha1/Provider --api-versions externaldata.gatekeeper.sh/v1beta1 --api-versions externaldata.gatekeeper.sh/v1beta1/Provider --api-versions externaldns.k8s.io/v1alpha1 --api-versions externaldns.k8s.io/v1alpha1/DNSEndpoint --api-versions flowcontrol.apiserver.k8s.io/v1beta1 --api-versions flowcontrol.apiserver.k8s.io/v1beta1/FlowSchema --api-versions flowcontrol.apiserver.k8s.io/v1beta1/PriorityLevelConfiguration --api-versions flowcontrol.apiserver.k8s.io/v1beta2 --api-versions flowcontrol.apiserver.k8s.io/v1beta2/FlowSchema --api-versions flowcontrol.apiserver.k8s.io/v1beta2/PriorityLevelConfiguration --api-versions ipam.schip.io/v1alpha1 --api-versions ipam.schip.io/v1alpha1/CIDRs --api-versions karpenter.k8s.aws/v1beta1 --api-versions karpenter.k8s.aws/v1beta1/EC2NodeClass --api-versions karpenter.sh/v1beta1 --api-versions karpenter.sh/v1beta1/NodeClaim --api-versions karpenter.sh/v1beta1/NodePool --api-versions keda.sh/v1alpha1 --api-versions keda.sh/v1alpha1/ClusterTriggerAuthentication --api-versions keda.sh/v1alpha1/ScaledJob --api-versions keda.sh/v1alpha1/ScaledObject --api-versions keda.sh/v1alpha1/TriggerAuthentication --api-versions monitoring.coreos.com/v1 --api-versions monitoring.coreos.com/v1/Alertmanager --api-versions monitoring.coreos.com/v1/PodMonitor --api-versions monitoring.coreos.com/v1/Probe --api-versions monitoring.coreos.com/v1/Prometheus --api-versions monitoring.coreos.com/v1/PrometheusRule --api-versions monitoring.coreos.com/v1/ServiceMonitor --api-versions monitoring.coreos.com/v1/ThanosRuler --api-versions monitoring.coreos.com/v1alpha1 --api-versions monitoring.coreos.com/v1alpha1/AlertmanagerConfig --api-versions mutations.gatekeeper.sh/v1 --api-versions mutations.gatekeeper.sh/v1/Assign --api-versions mutations.gatekeeper.sh/v1/AssignMetadata --api-versions mutations.gatekeeper.sh/v1/ModifySet --api-versions mutations.gatekeeper.sh/v1alpha1 --api-versions mutations.gatekeeper.sh/v1alpha1/Assign --api-versions mutations.gatekeeper.sh/v1alpha1/AssignMetadata --api-versions mutations.gatekeeper.sh/v1alpha1/ModifySet --api-versions mutations.gatekeeper.sh/v1beta1 --api-versions mutations.gatekeeper.sh/v1beta1/Assign --api-versions mutations.gatekeeper.sh/v1beta1/AssignMetadata --api-versions mutations.gatekeeper.sh/v1beta1/ModifySet --api-versions networking.k8s.aws/v1alpha1 --api-versions networking.k8s.aws/v1alpha1/PolicyEndpoint --api-versions networking.k8s.io/v1 --api-versions networking.k8s.io/v1/Ingress --api-versions networking.k8s.io/v1/IngressClass --api-versions networking.k8s.io/v1/NetworkPolicy --api-versions node.k8s.io/v1 --api-versions node.k8s.io/v1/RuntimeClass --api-versions operator.tigera.io/v1 --api-versions operator.tigera.io/v1/APIServer --api-versions operator.tigera.io/v1/ImageSet --api-versions operator.tigera.io/v1/Installation --api-versions operator.tigera.io/v1/TigeraStatus --api-versions policy/v1 --api-versions policy/v1/PodDisruptionBudget --api-versions projectcalico.org/v3 --api-versions projectcalico.org/v3/BGPConfiguration --api-versions projectcalico.org/v3/BGPPeer --api-versions projectcalico.org/v3/BlockAffinity --api-versions projectcalico.org/v3/CalicoNodeStatus --api-versions projectcalico.org/v3/ClusterInformation --api-versions projectcalico.org/v3/FelixConfiguration --api-versions projectcalico.org/v3/GlobalNetworkPolicy --api-versions projectcalico.org/v3/GlobalNetworkSet --api-versions projectcalico.org/v3/HostEndpoint --api-versions projectcalico.org/v3/IPAMConfiguration --api-versions projectcalico.org/v3/IPPool --api-versions projectcalico.org/v3/IPReservation --api-versions projectcalico.org/v3/KubeControllersConfiguration --api-versions projectcalico.org/v3/NetworkPolicy --api-versions projectcalico.org/v3/NetworkSet --api-versions projectcalico.org/v3/Profile --api-versions rbac.authorization.k8s.io/v1 --api-versions rbac.authorization.k8s.io/v1/ClusterRole --api-versions rbac.authorization.k8s.io/v1/ClusterRoleBinding --api-versions rbac.authorization.k8s.io/v1/Role --api-versions rbac.authorization.k8s.io/v1/RoleBinding --api-versions rbac.schip.io/v1alpha1 --api-versions rbac.schip.io/v1alpha1/OktaClusterRoleBinding --api-versions rbac.schip.io/v1alpha1/OktaRoleBinding --api-versions scheduling.k8s.io/v1 --api-versions scheduling.k8s.io/v1/PriorityClass --api-versions schip.io/v1alpha1 --api-versions schip.io/v1alpha1/Capability --api-versions status.gatekeeper.sh/v1beta1 --api-versions status.gatekeeper.sh/v1beta1/ConstraintPodStatus --api-versions status.gatekeeper.sh/v1beta1/ConstraintTemplatePodStatus --api-versions status.gatekeeper.sh/v1beta1/MutatorPodStatus --api-versions storage.k8s.io/v1 --api-versions storage.k8s.io/v1/CSIDriver --api-versions storage.k8s.io/v1/CSINode --api-versions storage.k8s.io/v1/CSIStorageCapacity --api-versions storage.k8s.io/v1/StorageClass --api-versions storage.k8s.io/v1/VolumeAttachment --api-versions storage.k8s.io/v1beta1 --api-versions storage.k8s.io/v1beta1/CSIStorageCapacity --api-versions templates.gatekeeper.sh/v1 --api-versions templates.gatekeeper.sh/v1/ConstraintTemplate --api-versions templates.gatekeeper.sh/v1alpha1 --api-versions templates.gatekeeper.sh/v1alpha1/ConstraintTemplate --api-versions templates.gatekeeper.sh/v1beta1 --api-versions templates.gatekeeper.sh/v1beta1/ConstraintTemplate --api-versions v1 --api-versions v1/ConfigMap --api-versions v1/Endpoints --api-versions v1/Event --api-versions v1/LimitRange --api-versions v1/Namespace --api-versions v1/Node --api-versions v1/PersistentVolume --api-versions v1/PersistentVolumeClaim --api-versions v1/Pod --api-versions v1/PodTemplate --api-versions v1/ReplicationController --api-versions v1/ResourceQuota --api-versions v1/Secret --api-versions v1/Service --api-versions v1/ServiceAccount --api-versions velero.io/v1 --api-versions velero.io/v1/Backup --api-versions velero.io/v1/BackupStorageLocation --api-versions velero.io/v1/DeleteBackupRequest --api-versions velero.io/v1/DownloadRequest --api-versions velero.io/v1/PodVolumeBackup --api-versions velero.io/v1/PodVolumeRestore --api-versions velero.io/v1/ResticRepository --api-versions velero.io/v1/Restore --api-versions velero.io/v1/Schedule --api-versions velero.io/v1/ServerStatusRequest --api-versions velero.io/v1/VolumeSnapshotLocation --api-versions vpcresources.k8s.aws/v1alpha1 --api-versions vpcresources.k8s.aws/v1alpha1/CNINode --api-versions vpcresources.k8s.aws/v1beta1 --api-versions vpcresources.k8s.aws/v1beta1/SecurityGroupPolicy --include-crds` failed exit status 1: Error: template: ingress-nginx/templates/controller-deployment.yaml:2:4: executing "ingress-nginx/templates/controller-deployment.yaml" at <include "isControllerTagValid" .>: error calling include: template: ingress-nginx/templates/_helpers.tpl:182:12: executing "isControllerTagValid" at <semverCompare ">=0.27.0-0" .Values.controller.image.tag>: error calling semverCompare: Invalid Semantic Version Use --debug flag to render out invalid YAML
```

   # what it does this PR

  - In #2 we produced an image like ghcr.io/adevinta/ingress-nginx/controller-chroot:354d5faa30694a590bf4f892f36587489ac88cb9 in this PR we add a right semver tag and since we are using 1.5.1 pinned version we change the image format ghcr.io/adevinta/ingress-nginx/controller-chroot:v1.5.1-354d5faa30694a590bf4f892f36587489ac88cb9
<details>
<summary>
Committer details
</summary>
Local-Branch: SCHIP
</details>